### PR TITLE
Fixes a crash on iOS 13 that occurs when logging

### DIFF
--- a/Pod/Classes/OAuthRequestController.m
+++ b/Pod/Classes/OAuthRequestController.m
@@ -92,9 +92,11 @@
         [_delegate didCancel];
         
     } else {
-        [self dismissViewControllerAnimated:YES completion:^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self dismissViewControllerAnimated:YES completion:^{
 
-        }];
+            }];
+        });
     }
 }
 


### PR DESCRIPTION
Basically ensures that 'dismissViewControllerAnimated' is called from the main thread.